### PR TITLE
Fix missing account & incorrect computation definition initialization

### DIFF
--- a/programs/cipher_score/src/lib.rs
+++ b/programs/cipher_score/src/lib.rs
@@ -213,7 +213,7 @@ pub struct EncryptedScoreShared {
 pub mod cipher_score {
     use std::vec;
 
-    use arcium_client::idl::arcium::types::{CircuitSource, OffChainCircuitSource};
+    use arcium_client::idl::arcium::types::{CallbackAccount, CircuitSource, OffChainCircuitSource};
 
 
     use super::*;
@@ -278,7 +278,12 @@ pub mod cipher_score {
             computation_offset,
             args,
             None,
-            vec![CalculateCreditScoreCallback::callback_ix(&[])],
+            vec![CalculateCreditScoreCallback::callback_ix(&[
+                CallbackAccount{
+                    pubkey: ctx.accounts.credit_account.key(),
+                    is_writable: true,
+                }
+            ])],
         )?;
         
         emit!(ScoreCalculationStarted {

--- a/tests/cipher_score.ts
+++ b/tests/cipher_score.ts
@@ -500,21 +500,8 @@ describe("CipherScore", () => {
         rawCircuit,
         true
       );
-    } else {
-      const finalizeTx = await buildFinalizeCompDefTx(
-        provider as anchor.AnchorProvider,
-        Buffer.from(offset).readUInt32LE(),
-        program.programId
-      );
-
-      const latestBlockhash = await provider.connection.getLatestBlockhash();
-      finalizeTx.recentBlockhash = latestBlockhash.blockhash;
-      finalizeTx.lastValidBlockHeight = latestBlockhash.lastValidBlockHeight;
-
-      finalizeTx.sign(owner);
-
-      await provider.sendAndConfirm(finalizeTx);
     }
+    
     return sig;
   }
 });


### PR DESCRIPTION
- Missing callback account caused the callback to fail
- Outdated computation definition initialization function caused the comp def initialization to fail